### PR TITLE
Update jar_loader print_stream to work with JRuby 1.7.4

### DIFF
--- a/lib/bind-it/jar_loader.rb
+++ b/lib/bind-it/jar_loader.rb
@@ -59,8 +59,8 @@ module BindIt
         file = Rjb::import('java.io.File')
       end
       ps = print_stream.new(file.new(self.log_file))
-      ps.write(::Time.now.strftime("[%m/%d/%Y at %I:%M%p]\n\n"))
-      system.setOut(ps)
+      # ps.write(::Time.now.strftime("[%m/%d/%Y at %I:%M%p]\n\n"))
+      # system.setOut(ps)
       system.setErr(ps)
     end
 


### PR DESCRIPTION
As mentioned here:
https://github.com/jenkinsci/jenkins.rb/issues/86#issuecomment-20467948
The behavior of printstream changed in JRuby 1.7. It does not accept strings. Instead of dealing with the alternative, I have just commented out the line that adds the date to the log file. I have also commented out the next line which messes up the Rails console. Sorry this is not a complete patch, just doing this now to get our project working.
