### PR TITLE
Set explicit version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source "https://rubygems.org"
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,16 @@
+PATH
+  remote: .
+  specs:
+    bind-it (0.2.7)
+      rjb (= 1.4.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rjb (1.4.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bind-it!

--- a/README.md
+++ b/README.md
@@ -65,4 +65,7 @@ obj = MyBindings::MyClass.new
 
 **Contributing**
 
+  gem install rjb -v 1.4.3
+  bundle
+
 Feel free to fork the project and send me a pull request!

--- a/bind-it.gemspec
+++ b/bind-it.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   if RUBY_PLATFORM =~ /java/
     s.platform = 'java'
   else
-    s.add_runtime_dependency 'rjb', '~>1.4.3'
+    s.add_runtime_dependency 'rjb', '1.4.3'
   end
-      
 end


### PR DESCRIPTION
Hi Louis. I'm trying to debug an issue with stanford-core-nlp included in a rails app, then also included in a ruby gem. I noticed that withouth the explicit rjb version requirement, when I "bundle" in the rails app, which specifies the gem version, the latest version as of this writing of rjb `1.4.9` is getting included instead of `1.4.3`. I tried to pin the version to 1.4.3, as I read elsewhere that version was tested. 

Unfortunately I'm still debugging the original issue, but I wanted to pass this along in case you wanted to consider pinning the rjb dependency to a specific version anyway. Personally I prefer this, as even the minor version of rjb could introduce bugs, but I leave it up to you as to whether you want to merge it or not.

Thanks.
